### PR TITLE
allow to send kafka headers

### DIFF
--- a/server/controllers/publisher.js
+++ b/server/controllers/publisher.js
@@ -24,14 +24,15 @@ module.exports = ({ strapi }) => ({
     );
     await publisher.producer.disconnect();
   },
-  publish: async (clientId, topic, message) => {
+  publish: async (clientId, topic, message, headers) => {
     try {
       const publisher = strapi.kafka.publishers.find(
         pub => pub.clientId === clientId,
       );
+      const msg = headers ? { headers, value: message } : { value: message }
       await publisher.producer.send({
         topic,
-        messages: [{ value: message }],
+        messages: [msg],
       });
       return true;
     } catch (err) {


### PR DESCRIPTION
KafkaJS allows to send headers in addition to messages: https://kafka.js.org/docs/producing#message-headers. This PR allows to send headers along with the message. 